### PR TITLE
ランキング画面におけるランキングのReadとCreateを実装

### DIFF
--- a/frontend/src/api/zundamonAPI.ts
+++ b/frontend/src/api/zundamonAPI.ts
@@ -1,5 +1,10 @@
 import axios, { AxiosInstance } from "axios";
 
+export type RankingType = {
+  name: string;
+  continuation_count: number;
+};
+
 const instance: AxiosInstance = axios.create({
   baseURL: "http://localhost:5000",
   timeout: 10000,
@@ -10,6 +15,30 @@ export const toZundamonAPI = async (text: string) => {
   try {
     const res = await instance.post("/siritori", {
       post_text: text,
+    });
+    return res;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export const getRanking = async () => {
+  try {
+    const res = await instance.get("/ranking");
+    return res.data as RankingType[];
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export const postRanking = async ({
+  name,
+  continuation_count,
+}: RankingType) => {
+  try {
+    const res = await instance.post("/ranking", {
+      name: name,
+      continuation_count: continuation_count,
     });
     return res;
   } catch (error) {

--- a/frontend/src/components/header.tsx
+++ b/frontend/src/components/header.tsx
@@ -18,7 +18,7 @@ const Header: Component = () => {
             lineHeight="80px"
             style={{"overflow": "hidden", "white-space": "nowrap", "text-overflow": "ellipsis"}}
           >
-            ずんだもん しりとり
+            ずんだもん しりとり
           </Typography>
         </AppBar>
       </Box>


### PR DESCRIPTION
## 内容
- /gameにアクセスすると、バックエンドからrankingデータを持ってきます
- ランキング登録ボタンをクリックするとrankingデータを送信します

## 関連issue
close #31 
close #32 
## スクリーンショット・動画など
<img width="698" alt="スクリーンショット 2022-12-11 6 56 14" src="https://user-images.githubusercontent.com/73931800/206876734-05458eea-3412-4328-a144-9f00ed3bb11c.png">


## その他