### PR TITLE
ランキング画面のレイアウトを修正する

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "clsx": "^1.1.1",
         "prop-types": "^15.8.1",
         "solid-app-router": "^0.4.2",
+        "solid-icons": "^1.0.4",
         "solid-js": "^1.4.2",
         "solid-js-form": "^0.1.5"
       },
@@ -1611,6 +1612,17 @@
         "solid-js": "^1.3.5"
       }
     },
+    "node_modules/solid-icons": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/solid-icons/-/solid-icons-1.0.4.tgz",
+      "integrity": "sha512-gJTp4in3+OYCs9WvDkSLt4Los2unR3Uoder8wjh15GsfP20xiNOLfPTJllXmn+fI8+k3x7bRYtLGIgWd9fUQug==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "peerDependencies": {
+        "solid-js": "*"
+      }
+    },
     "node_modules/solid-js": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.4.4.tgz",
@@ -2839,6 +2851,12 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/solid-app-router/-/solid-app-router-0.4.2.tgz",
       "integrity": "sha512-+NrLcmqYssx8DcbpcLBaYPqfTRtS+rkfbxMhLH8MHfTcTkdZfrkWQK7lsUvuPCebGEzfaPZJvHqBwhPrCXAmxg==",
+      "requires": {}
+    },
+    "solid-icons": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/solid-icons/-/solid-icons-1.0.4.tgz",
+      "integrity": "sha512-gJTp4in3+OYCs9WvDkSLt4Los2unR3Uoder8wjh15GsfP20xiNOLfPTJllXmn+fI8+k3x7bRYtLGIgWd9fUQug==",
       "requires": {}
     },
     "solid-js": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "clsx": "^1.1.1",
     "prop-types": "^15.8.1",
     "solid-app-router": "^0.4.2",
+    "solid-icons": "^1.0.4",
     "solid-js": "^1.4.2",
     "solid-js-form": "^0.1.5"
   }

--- a/frontend/src/Ranking.tsx
+++ b/frontend/src/Ranking.tsx
@@ -18,6 +18,9 @@ import Paper from "@suid/material/Paper";
 import TableHead from "@suid/material/TableHead";
 import TableCell from "@suid/material/TableCell";
 import TableBody from "@suid/material/TableBody";
+import CircularProgress from "@suid/material/CircularProgress";
+import Typography from "@suid/material/Typography";
+import { TwitterIntentTweet } from "./components/twitterIntentTweet";
 
 type Props = {
   continuation_count?: number;
@@ -49,41 +52,29 @@ const Ranking: Component<Props> = ({ continuation_count = 0 }) => {
     setIsPost(true);
   };
   return (
-    <div
+    <Box
       style={{
         height: "100vh",
-        "background-color": "#D9D9D9",
-        width: "100%",
       }}
     >
       <Header />
       {isLoading() ? (
-        <h2>Loading...</h2>
+        <CircularProgress color="secondary" />
       ) : (
-        <Grid container height="auto" bgcolor="#4CD0A9">
-          <Grid item xs={3}>
-            <h1>あなたのスコアは{continuation_count}回なのだ!</h1>
+        <Grid container height="auto" bgcolor="#4CD0A9" padding={3}>
+          <Grid item paddingY={3} xs={12} container justifyContent="center">
+            <Typography variant="h3">
+              あなたのスコアは{continuation_count}回なのだ!
+            </Typography>
           </Grid>
-          <Grid
-            item
-            xs={5}
-            container
-            justifyContent="space-around"
-            alignItems="flex-start"
-            direction="column"
-          >
-            <Box
-              sx={{
-                width: "100%",
-                bgcolor: "background.paper",
-              }}
-            >
+          <Grid item container>
+            <Grid item xs={6}>
               <TableContainer component={Paper}>
                 <Table>
                   <TableHead>
                     <TableRow>
                       <TableCell align="left">順位</TableCell>
-                      <TableCell align="left">ユーザ名</TableCell>
+                      <TableCell align="left">プレイヤー名</TableCell>
                       <TableCell align="left">スコア</TableCell>
                     </TableRow>
                   </TableHead>
@@ -100,49 +91,58 @@ const Ranking: Component<Props> = ({ continuation_count = 0 }) => {
                   </TableBody>
                 </Table>
               </TableContainer>
-            </Box>
-            <Grid container>
-              <Grid item xs={6}>
-                <TextField
-                  value={text()}
-                  onChange={handleChange}
-                  fullWidth
-                  label="名前を入力(アルファベット)"
-                />
+            </Grid>
+            <Grid item xs={6} container paddingX={1}>
+              <Grid item container>
+                <Grid item xs={5}>
+                  <TextField
+                    value={text()}
+                    onChange={handleChange}
+                    fullWidth
+                    label="プレイヤー名を入力"
+                  />
+                </Grid>
+                <Grid flexGrow={1} />
+                <Grid item xs={6}>
+                  {isPost() ? (
+                    <Button
+                      disabled={true}
+                      onClick={rankingHandleClick}
+                      variant="contained"
+                    >
+                      送信済み
+                    </Button>
+                  ) : (
+                    <Button
+                      disabled={isPost()}
+                      onClick={rankingHandleClick}
+                      variant="contained"
+                      color="success"
+                    >
+                      ランキングに登録する
+                    </Button>
+                  )}
+                </Grid>
               </Grid>
-              <Grid item xs={6}>
-                {isPost() ? (
-                  <Button
-                    disabled={true}
-                    onClick={rankingHandleClick}
-                    variant="contained"
-                  >
-                    送信済み
+              <Grid item container>
+                <Grid item xs={6}>
+                  <Button variant="contained" onClick={() => navigate("/game")} color="warning">
+                    ゲームをやり直す
                   </Button>
-                ) : (
-                  <Button
-                    disabled={isPost()}
-                    onClick={rankingHandleClick}
-                    variant="contained"
-                  >
-                    ランキングに登録する
-                  </Button>
-                )}
+                </Grid>
+                <Grid item xs={6}>
+                  <TwitterIntentTweet
+                    text={continuation_count+"回続きました！"}
+                    hashtags={["ずんだもんしりとり"]}
+                  />
+                </Grid>
               </Grid>
             </Grid>
-
-            <Button variant="contained" onClick={() => navigate("/game")}>
-              ゲームをやり直す
-            </Button>
-            <Button variant="contained">Twitterで共有する</Button>
-          </Grid>
-          <Grid item xs={4}>
-            <Zunda />
           </Grid>
           <GameTable />
         </Grid>
       )}
-    </div>
+    </Box>
   );
 };
 

--- a/frontend/src/components/twitterIntentTweet.tsx
+++ b/frontend/src/components/twitterIntentTweet.tsx
@@ -1,0 +1,47 @@
+import Button from "@suid/material/Button";
+import { Component, ComponentProps } from "solid-js";
+import { AiFillTwitterCircle } from "solid-icons/ai";
+
+type TwitterIntentTweetProps = {
+  text?: string;
+  url?: string;
+  hashtags?: string[];
+  via?: string;
+  related?: string[];
+  in_reply_to?: string;
+} & Omit<ComponentProps<"a">, "href" | "target" | "rel">;
+
+export const TwitterIntentTweet: Component<TwitterIntentTweetProps> = ({
+  text,
+  url,
+  hashtags,
+  via,
+  related,
+  in_reply_to,
+  ...intrinsicProps
+}) => {
+  const _url = new URL("https://twitter.com/intent/tweet");
+
+  if (text !== undefined) _url.searchParams.set("text", text);
+  if (url !== undefined) _url.searchParams.set("url", url);
+  if (hashtags !== undefined)
+    _url.searchParams.set("hashtags", hashtags.join(","));
+  if (via !== undefined) _url.searchParams.set("via", via);
+  if (related !== undefined)
+    _url.searchParams.set("related", related.join(","));
+  if (in_reply_to !== undefined)
+    _url.searchParams.set("in_reply_to", in_reply_to);
+
+  return (
+    <Button color="primary" variant="contained">
+      <a
+        href={_url.toString()}
+        target="_blank"
+        rel="noopener noreferrer"
+        {...intrinsicProps}
+      >
+        <AiFillTwitterCircle />
+      </a>
+    </Button>
+  );
+};


### PR DESCRIPTION
## 内容

シンプルなレイアウトにしました。

## 関連issue
close #36 
## スクリーンショット・動画など
<img width="1109" alt="スクリーンショット 2022-12-11 10 13 48" src="https://user-images.githubusercontent.com/73931800/206881809-ba69fdd2-bf46-4716-9f25-6478726c6df5.png">

## その他
時間余ったら修正します